### PR TITLE
fix(serialization): preventing NPE when Customer.moipAccount is null during serialization to String(Json)

### DIFF
--- a/src/main/java/br/com/moip/resource/Customer.java
+++ b/src/main/java/br/com/moip/resource/Customer.java
@@ -66,7 +66,9 @@ public class Customer {
         return fundingInstrument;
     }
 
-    public String getMoipAccountId() { return moipAccount.getId(); }
+    public String getMoipAccountId() { 
+        return moipAccount != null ? moipAccount.getId() : null;
+    }
 
     public CustomerLinks getLinks() { return _links; }
 


### PR DESCRIPTION
Serialization with jackson fails when moipAccount field is null.

Kotlin code to reproduce the issue.
```
    // all fields null(which is ok)
    val c = Customer()
    val objectMapper = ObjectMapper()
    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
    val json = objectMapper.writeValueAsString(c) // throws NPE, since it evaluates all fields.
```
