### PR TITLE
Alteração para forçar o envio do Body vazio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 group = 'br.com.moip'
 archivesBaseName = "java-sdk"
-version = '4.7.5'
+version = '4.7.6'
 
 description = "Moip v2 SDK"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 group = 'br.com.moip'
 archivesBaseName = "java-sdk"
-version = '4.7.3'
+version = '4.7.5'
 
 description = "Moip v2 SDK"
 

--- a/src/main/java/br/com/moip/API.java
+++ b/src/main/java/br/com/moip/API.java
@@ -51,7 +51,7 @@ public class API {
     public PlugPagTokenV2API plugPagTokenV2() { return new PlugPagTokenV2API(client); }
 
     public ConnectAPI connect() {
-        if (client.getEndpoint() == Client.PRODUCTION) {
+        if (client.getEndpoint() == Client.PRODUCTION || client.getEndpoint() == Client.PRODUCTION_WAF) {
             return new ConnectAPI(new Client(Client.CONNECT_PRODUCTION, client.getAuthentication()));
         }
 

--- a/src/main/java/br/com/moip/API.java
+++ b/src/main/java/br/com/moip/API.java
@@ -51,7 +51,7 @@ public class API {
     public PlugPagTokenV2API plugPagTokenV2() { return new PlugPagTokenV2API(client); }
 
     public ConnectAPI connect() {
-        if (client.getEndpoint() == Client.PRODUCTION || client.getEndpoint() == Client.PRODUCTION_WAF) {
+        if (client.getEndpoint() == Client.PRODUCTION) {
             return new ConnectAPI(new Client(Client.CONNECT_PRODUCTION, client.getAuthentication()));
         }
 

--- a/src/main/java/br/com/moip/Client.java
+++ b/src/main/java/br/com/moip/Client.java
@@ -37,7 +37,6 @@ public class Client {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Client.class);
     public static final String PRODUCTION = "https://api.moip.com.br";
-    public static final String PRODUCTION_WAF = "https://api-waf.moip.com.br";
     public static final String SANDBOX = "https://sandbox.moip.com.br";
     public static final String CONNECT_PRODUCTION = "https://connect.moip.com.br";
     public static final String CONNECT_SANDBOX = "https://connect-sandbox.moip.com.br";

--- a/src/main/java/br/com/moip/Client.java
+++ b/src/main/java/br/com/moip/Client.java
@@ -37,6 +37,7 @@ public class Client {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Client.class);
     public static final String PRODUCTION = "https://api.moip.com.br";
+    public static final String PRODUCTION_WAF = "https://api-waf.moip.com.br";
     public static final String SANDBOX = "https://sandbox.moip.com.br";
     public static final String CONNECT_PRODUCTION = "https://connect.moip.com.br";
     public static final String CONNECT_SANDBOX = "https://connect-sandbox.moip.com.br";
@@ -108,6 +109,7 @@ public class Client {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("User-Agent", USER_AGENT);
             conn.setRequestProperty("Content-type", requestProps.contentType.getMimeType());
+
             if (requestProps.accept != null) conn.setRequestProperty("Accept", requestProps.accept);
 
             conn.setRequestMethod(requestProps.method);
@@ -124,7 +126,7 @@ public class Client {
             LOGGER.debug("---> {} {}", requestProps.method, conn.getURL().toString());
             logHeaders(conn.getRequestProperties().entrySet());
 
-            if (requestProps.object != null) {
+            if (requestProps.shouldSendBody()) {
                 conn.setDoOutput(true);
                 String body = getBody(requestProps.object, requestProps.contentType);
 
@@ -136,7 +138,7 @@ public class Client {
                 writer.close();
                 wr.flush();
                 wr.close();
-            }
+           }
 
             LOGGER.debug("---> END HTTP");
 
@@ -258,6 +260,12 @@ public class Client {
         public ContentType getContentType() { return contentType; }
 
         public String getAccept() { return accept; }
+
+        public boolean shouldSendBody(){
+            if(object != null)
+                return true;
+            return getMethod().equals("POST") || getMethod().equals("PUT") || getMethod().equals("PATCH");
+        }
     }
 
     private static class RequestPropsBuilder extends RequestProps {


### PR DESCRIPTION
Foi necessario a mudança para evitar o erro 411. Problema ocorria ao tentar realizar a captura do pagamento. Como o capture não envia o body mesmo sendo vazio. Era retornado esse erro no momento da authenticação.